### PR TITLE
fix: redirect non-admin users to home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Fixed admin authentication by storing and checking roles in Supabase user metadata
 - Improved auth state management and role checking in AuthContext
+- Added automatic redirect to home for non-admin users attempting to access admin pages
 
 
 ## [Unreleased]

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { Session, User } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
+import { useNavigate } from 'react-router-dom';
 
 type UserRole = {
   role: string;
@@ -28,6 +29,7 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate();
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -48,6 +50,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     console.log('Setting admin status:', { email: user.email, role, isAdmin: adminStatus });
     
     setIsAdmin(adminStatus);
+    
+    // Redirect non-admin users to home
+    if (!adminStatus && window.location.pathname.startsWith('/admin')) {
+      console.log('Non-admin user detected, redirecting to home');
+      navigate('/');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

- Add automatic redirect to home page for non-admin users trying to access /admin
- Use React Router navigation for client-side routing
- Update CHANGELOG with redirect feature

## Testing

1. Log in with non-admin user
2. Try to access /admin
3. Verify you are redirected to home page
4. Log in with admin user
5. Verify you can access /admin without redirect