### PR TITLE
fix: sign out non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 - Fixed admin authentication by storing and checking roles in Supabase user metadata
 - Improved auth state management and role checking in AuthContext
-- Added automatic redirect to home for non-admin users attempting to access admin pages
+- Added automatic logout for non-admin users attempting to access admin pages
 
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can find these values in your Supabase project settings. The admin dashboard
 
 ### Admin Access
 
-The site includes a secure admin dashboard for managing tournament details and content. Admin access is controlled through Supabase user metadata, with role-based access control implemented. Contact the project maintainers to request admin access.
+The site includes a secure admin dashboard for managing tournament details and content. Admin access is controlled through Supabase user metadata, with role-based access control implemented. For security reasons, any unauthorized attempts to access admin pages will result in an automatic logout. Contact the project maintainers to request admin access.
 
 **Edit a file directly in GitHub**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@
 - [x] Implement interactive Supabase connection status
 - [x] Set up secure admin authentication using Supabase
 - [x] Implement role-based access control
+- [x] Add security measures for unauthorized admin access
 - [ ] Set up data management for sponsors
 - [ ] Create tournament details configuration system
 - [ ] Implement dynamic date management across site

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -51,10 +51,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     
     setIsAdmin(adminStatus);
     
-    // Redirect non-admin users to home
+    // Sign out non-admin users
     if (!adminStatus && window.location.pathname.startsWith('/admin')) {
-      console.log('Non-admin user detected, redirecting to home');
-      navigate('/');
+      console.log('Non-admin user detected, signing out');
+      supabase.auth.signOut().then(() => {
+        navigate('/');
+      });
     }
   };
 


### PR DESCRIPTION
## Changes

- Change behavior to sign out non-admin users when they try to access /admin
- Update CHANGELOG to reflect new behavior

## Testing

1. Log in with non-admin user
2. Try to access /admin
3. Verify you are signed out and redirected to home page
4. Log in with admin user
5. Verify you can access /admin without being signed out