### PR TITLE
fix: preserve original image dimensions in Cloudinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Craven Cancer Classic website will be documented in t
   * Improved grid layout for better thumbnail presentation
   * Added single-file upload restriction for sponsor logos
   * Improved sponsor metadata handling with optional website field
+  * Added preservation of original image dimensions in Cloudinary
 
 ### Changed
 - Simplified application architecture

--- a/app/api/cloudinary/list-resources/route.ts
+++ b/app/api/cloudinary/list-resources/route.ts
@@ -20,7 +20,8 @@ export async function GET() {
       },
       type: 'upload',
       max_results: 500,
-      prefix: 'sponsors' // This will look in the sponsors folder
+      prefix: 'sponsors', // This will look in the sponsors folder
+      metadata: true // Include metadata
     });
 
     // Get all folders

--- a/app/api/sponsors/upload/route.ts
+++ b/app/api/sponsors/upload/route.ts
@@ -52,10 +52,10 @@ export async function POST(request: NextRequest) {
           // Use sponsor name for better identification
           public_id: `${metadata.level}/${metadata.name.toLowerCase().replace(/[^a-z0-9]/g, '-')}-${metadata.year}`,
           display_name: `${metadata.name} (${metadata.level} Sponsor ${metadata.year})`,
-          // Optimize image on upload
-          transformation: [
-            { width: 500, height: 375, crop: 'fill', quality: 'auto', format: 'auto' },
-            { width: 300, height: 300, crop: 'fill', quality: 'auto', format: 'auto' }
+          // Store original and create thumbnails
+          eager: [
+            { width: 500, height: 375, crop: 'fill', fetch_format: 'auto', quality: 'auto:good' },
+            { width: 300, height: 300, crop: 'fill', fetch_format: 'auto', quality: 'auto:good' }
           ],
           // Add metadata as Cloudinary context
           context: {

--- a/components/admin/PhotoGallery.tsx
+++ b/components/admin/PhotoGallery.tsx
@@ -225,11 +225,11 @@ export default function PhotoGallery() {
           <div 
             key={resource.public_id} 
             className={cn(
-              "bg-white p-4 rounded-lg shadow transition-colors",
+              "bg-white p-4 rounded-lg shadow transition-colors flex flex-col items-center text-center",
               selectedImages.has(resource.public_id) && "bg-blue-50"
             )}
           >
-            <div className="relative aspect-square mb-2 group h-[150px]">
+            <div className="relative aspect-square mb-2 group h-[150px] w-full">
               <Image
                 src={resource.secure_url}
                 alt={resource.public_id}
@@ -250,11 +250,12 @@ export default function PhotoGallery() {
                 )}
               </button>
             </div>
-            <div className="text-xs space-y-1">
+            <div className="text-xs space-y-1 w-full">
               <div>
-                <p className="font-semibold truncate">{resource.public_id}</p>
-                <p className="text-gray-500">{new Date(resource.created_at).toLocaleDateString()}</p>
-                <p className="text-gray-500">{resource.format} - {(resource.bytes / 1024).toFixed(2)}KB</p>
+                <p className="font-semibold truncate text-center">{resource.display_name || resource.public_id.split('/').pop()}</p>
+                <p className="text-gray-500 text-center">{new Date(resource.created_at).toLocaleDateString()}</p>
+                <p className="text-gray-500 text-center">{resource.format.toUpperCase()} • {(resource.bytes / 1024).toFixed(1)} KB</p>
+                <p className="text-gray-500 text-center">Original: {resource.width}×{resource.height}</p>
               </div>
               <AlertDialog>
                 <AlertDialogTrigger asChild>


### PR DESCRIPTION
## Changes
- Replace transformation with eager to keep original image untransformed
- Fix eager transformation syntax for format and quality settings
- Add original image dimensions to PhotoGallery display
- Update CHANGELOG

## Testing
- [x] Verified image upload works with new eager transformations
- [x] Confirmed original image dimensions are preserved
- [x] Checked thumbnail generation still works correctly

## Screenshots
Before: All images showed 300×300 dimensions
After: Images show their original dimensions